### PR TITLE
Add WHO Guidleine on COVID-19 outbreak for Health Workers

### DIFF
--- a/WHO/rights-roles-and-responsibilities-of-health-workers/rights-roles-and-responsibilities-of-health-workers.txt
+++ b/WHO/rights-roles-and-responsibilities-of-health-workers/rights-roles-and-responsibilities-of-health-workers.txt
@@ -1,0 +1,47 @@
+Coronavirus disease (COVID-19) outbreak: rights, roles and responsibilities of health workers, including key considerations for occupational safety and health
+
+Interim guidance
+19 March 2020
+
+Background
+Health workers are at the front line of the COVID-19 outbreak response and as such are exposed to hazards that put them at risk of infection. Hazards include pathogen exposure,long working hours, psychological distress, fatigue, occupational burnout, stigma, and physical and psychological violence. This document highlights the rights and responsibilities of health workers, including the specific measures needed to protect occupational safety and health.
+
+Health work rights, roles and responsibilities
+Health worker rights include the expectation that employers and managers in health facilities:
+- assume overall responsibility to ensure that all necessary preventive and protective measures are taken to minimize occupational safety and health risks; (Including implementation of occupational safety and health management systems to identify hazards and assess risks to health and safety; IPC measures; and zero-tolerance policies towards workplace violence and harassment.)
+- provide information, instruction, and training on occupational safety and health, including;
+- refresher training on infection prevention and control (IPC);
+- use, putting on, taking off and disposal of personal protective equipment (PPE);
+- provide adequate IPC and PPE supplies (masks, gloves, goggles, gowns, hand sanitizer, soap and water, cleaning supplies) in sufficient quantity to those caring for suspected or confirmed COVID-19 patients, such that workers do not incur expenses for occupational safety and health requirements;
+- familiarize personnel with technical updates on COVID-19 and provide appropriate tools to assess, triage, test, and treat patients, and to share IPC information with patients and the public;
+- provide appropriate security measures as needed for personal safety;
+- provide a blame-free environment in which health workers can report on incidents, such as exposures to blood or bodily fluids from the respiratory system, or cases of violence, and adopt measures for immediate follow up, including support to victims;
+- advise health workers on self-assessment, symptom reporting, and staying home when ill;
+- maintain appropriate working hours with breaks;
+- consult with health workers on occupational safety and health aspects of their work, and notify the labour inspectorate of cases of occupational diseases;
+- allow health workers to exercise the right to remove themselves from a work situation that they have reasonable justification to believe presents an imminent and serious danger to their life or health, and protect health workers exercising this right from any undue consequences;
+- not require health workers to return to a work situation where there has been a serious danger to life or health until any necessary remedial action has been taken;
+- honour the right to compensation, rehabilitation, and curative services for health workers infected with COVID-19 following exposure in the workplace – considered as an occupational disease arising from occupational exposure;
+- provide access to mental health and counselling resources; and
+- enable cooperation between management and health workers and their representatives.
+
+Health workers should:
+- follow established occupational safety and health procedures, avoid exposing others to health and safety risks, and participate in employer-provided occupational safety and health training;
+- use provided protocols to assess, triage, and treat patients;
+- treat patients with respect, compassion, and dignity;
+- maintain patient confidentiality;
+- swiftly follow established public health reporting procedures of suspected and confirmed cases;
+- provide or reinforce accurate IPC and public health information, including to concerned people who have neither symptoms nor risk;
+- put on, use, take off, and dispose of PPE properly;
+- self-monitor for signs of illness and self-isolate and report illness to managers, if it occurs;
+- advise management if they are experiencing signs of undue stress or mental health challenges that require supportive interventions; and 
+- report to their immediate supervisor any situation which they have reasonable justification to believe
+presents an imminent and serious danger to life or health.
+
+Additional resources
+- Emerging respiratory viruses, including COVID-19: methods for detection, prevention, response and control.
+- WHO COVID-19 technical guidance
+
+WHO continues to monitor the situation closely for any changes that may affect this interim guidance. Should any factors change, WHO will issue a further update. Otherwise, this interim guidance document will expire 2 years after the date of publication.
+
+© World Health Organization 2020. Some rights reserved. This work is available under the CC BY-NC-SA 3.0 IGO licence.


### PR DESCRIPTION
Add WHO Guideline on COVID-19 outbreak for Health Workers: Rights, Roles and Responsibilities of health workers, for translation